### PR TITLE
Fix:free_sema

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -129,7 +129,7 @@ struct thread {
 	struct file *running; // 현재 실행 중인 파일
 	int exit_status; // 프로세스의 종료 유무 확인
 
-	struct semaphore fork_sema; // fork가 완료될 때 
+	struct semaphore fork_sema; // fork가 완료될 때 sema_up 수행
     struct semaphore free_sema; // 자식 프로세스가 종료될 때까지 부모 프로세스는 대기
 	struct semaphore wait_sema; // 자식 프로세스가 종료될 때까지 대기. 종료 상태 저장
 	

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -84,24 +84,29 @@ initd (void *f_name) {
 
 /* Clones the current process as `name`. Returns the new process's thread id, or
  * TID_ERROR if the thread cannot be created. */
+
+/* 현재 프로세스로 'name'이라는 이름을 가진 프로세스를 복사한다.
+ * 성공 시, 새 프로세스의 tid 반환
+ * 실패 시, TID_ERROR(-1) 반환 */
 tid_t
 process_fork (const char *name, struct intr_frame *if_ UNUSED) {
 	/* Clone current thread to new thread.*/
 
 	struct thread *curr = thread_current();
 
-	memcpy(&curr->parent_if, if_, sizeof(struct intr_frame)); // 전달받은 intr_frame을 현재 parent_if에 복사한다.
+	memcpy(&curr->parent_if, if_, sizeof(struct intr_frame)); // 전달받은 intr_frame을 parent_if필드에 복사한다.
+	// ↳ '__do_fork' 에서 자식 프로세스에 부모의 컨텍스트 정보를 복사하기 위함(부모의 인터럽트 프레임을 찾는 용도로 사용)
 
 	tid_t tid = thread_create(name, PRI_DEFAULT, __do_fork, curr); // __do_fork를 실행하는 스레드 생성, 현재 스레드를 인자로 넘겨준다.
 	if (tid == TID_ERROR)
 		return TID_ERROR;
 
 	struct thread *child = get_child_process(tid);
-	sema_down(&child->fork_sema); // wait until child loads
+	sema_down(&child->fork_sema); // 자식 프로세스가 로드될 때까지 부모 프로세스는 대기한다.
 	if (child->exit_status == TID_ERROR)
 		return TID_ERROR;
 
-	return tid;
+	return tid; // 부모 프로세스의 리턴값 : 생성한 자식 프로세스의 tid
 }
 
 #ifndef VM
@@ -164,20 +169,23 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 static void
 __do_fork (void *aux) {
 	struct intr_frame if_;
-	struct thread *parent = (struct thread *) aux;
-	struct thread *current = thread_current ();
+	struct thread *parent = (struct thread *) aux; // 부모 프로세스
+	struct thread *current = thread_current (); // 새로 생성된 자식 프로세스
 	/* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
+	/* TODO: process_fork의 두 번째 인자인 parent_if를 전달한다. */
 	struct intr_frame *parent_if;
 	bool succ = true;
 
 	parent_if = &parent->parent_if; // process_fork에서 복사 해두었던 intr_frame
 	/* 1. Read the cpu context to local stack. */
+	/* 1. 부모의 인터럽트 프레임을 읽어온다.(if_로 복사) */
 	memcpy (&if_, parent_if, sizeof (struct intr_frame));
 
-	if_.R.rax = 0 ; // ! if_의 리턴값을 0으로 설정한다.
+	if_.R.rax = 0; // fork 시스템 콜의 결과로 자식 프로세스는 0을 리턴해야하므로 0을 넣어준다.
 
 	/* 2. Duplicate PT */
-	current->pml4 = pml4_create();
+	/* 2. 페이지 테이블을 복제한다. */
+	current->pml4 = pml4_create(); // 부모의 pte를 복사하기 위해 페이지 테이블을 생성한다.
 	if (current->pml4 == NULL)
 		goto error;
 
@@ -187,7 +195,8 @@ __do_fork (void *aux) {
 	if (!supplemental_page_table_copy (&current->spt, &parent->spt))
 		goto error;
 #else
-	if (!pml4_for_each (parent->pml4, duplicate_pte, parent))
+	// "pml4_for_each" : Apply FUNC to each available pte entries including kernel's.
+	if (!pml4_for_each (parent->pml4, duplicate_pte, parent)) // "duplicate_pte" : 페이지 테이블을 복제하는 함수(부모 -> 자식) 
 		goto error;
 #endif
 
@@ -196,23 +205,29 @@ __do_fork (void *aux) {
 	 * TODO:       in include/filesys/file.h. Note that parent should not return
 	 * TODO:       from the fork() until this function successfully duplicates
 	 * TODO:       the resources of parent.*/
+	/*
+	 * 파일 객체를 복제하려면 'file_duplicate'를 사용하라.
+	 * 이 함수가 부모의 리소스를 성공적으로 복제할 때까지 부모 프로세스는 fork로 부터 리턴할 수 없다.
+	*/
 	if (parent->next_fd == FDCOUNT_LIMIT)
 		goto error;
 
 	// 부모의 fdt를 자식의 fdt로 복사한다.
 	for (int fd = 2; fd < FDCOUNT_LIMIT; fd++) {
 		struct file *file = parent->fdt[fd];
-		if (file == NULL)
+		if (file == NULL) // fd엔트리가 없는 상태에는 그냥 건너뛴다.
 			continue;
 		current->fdt[fd] = file_duplicate (file);
 	}
 
 	current->next_fd = parent->next_fd; // 부모의 next_fd를 자식의 next_fd로 옮겨준다.
-	sema_up(&current->fork_sema);
+	sema_up(&current->fork_sema); // fork가 정상적으로 완료되었으므로 현재 wait중인 parent를 다시 실행 가능 상태로 만든다. 
+
 	/* Finally, switch to the newly created process. */
+	/* 새로 생성된 프로세스에 대해 컨텍스트 스위치를 수행한다. */
 	if (succ)
 		do_iret (&if_);
-error:
+error: // 제대로 복제가 안된 상태 - TID_ERROR 리턴 
 	sema_up(&current->fork_sema);
 	exit(TID_ERROR);
 	// thread_exit ();
@@ -254,10 +269,6 @@ process_exec (void *f_name) {
 		return -1;
 	}
 
-	/* Initialize interrupt frame and load executable. */
-	// argument_stack(argv, argc, &_if.rsp);
-	// hex_dump(_if.rsp, _if.rsp, USER_STACK - _if.rsp, true);
-
 	argument_stack(argc, argv, &_if); // argc, argv로 커맨드 라인 파싱
 	// hex_dump(_if.rsp, _if.rsp, USER_STACK - _if.rsp, true); // 메모리에 적재된 상태 출력
 
@@ -276,6 +287,10 @@ process_exec (void *f_name) {
  *
  * This function will be implemented in problem 2-2.  For now, it
  * does nothing. */
+/* 스레드 TID가 종료될 때까지 기다렸다가 종료 상태를 반환한다.
+ * 커널에 의해 종료된 경우(예외로 인해 종료된 경우) -1을 반환한다.
+ * TID가 잘못되었거나 TID가 호출 프로세스의 하위 프로세스가 아니거나 
+ * process_wait()이미 성공적으로 호출되었을 때, 대기하지 않고 -1을 즉시 반환한다. */
 int
 process_wait (tid_t child_tid UNUSED) {
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
@@ -286,15 +301,16 @@ process_wait (tid_t child_tid UNUSED) {
 	// return -1;
 	struct thread *child = get_child_process(child_tid);
 
-	if(child == NULL)
+	if(child == NULL) // 해당 자식이 존재하지 않는다면 -1 리턴
 		return -1;
 
 	sema_down(&child->wait_sema); // 자식 프로세스가 종료할 때까지 대기한다.
+	// 컨텍스트 스위칭 발생
 
 	int exit_status = child->exit_status; // 자식으로 부터 종료인자를 전달 받고 리스트에서 삭제한다.
 	list_remove(&child->child_elem);
 	
-	sema_up(&child->free_sema); // 자식 프로세스 종료 상태를 받은 후 자식 프로세스를 종료하게 한다.
+	// sema_up(&child->free_sema); // 자식 프로세스 종료 상태를 받은 후 자식 프로세스를 종료하게 한다.
 
 	return exit_status;
 }
@@ -317,7 +333,8 @@ process_exit (void) {
 	process_cleanup ();
 
 	sema_up(&curr->wait_sema); // 부모 프로세스가 자식 프로세스의 종료상태를 확인하게 한다.
-	sema_down(&curr->free_sema); // ! 부모 프로세스가 자식 프로세스의 종료인자를 받을때 까지 대기한다. 
+	thread_sleep(300);
+	// sema_down(&curr->free_sema); // 부모 프로세스가 자식 프로세스의 종료 상태를 받을때 까지 대기한다. 
 }
 
 /* Free the current process's resources. */

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -157,11 +157,24 @@ exit(int status) {
 	thread_exit();
 }
 
+/**
+ * @brief 부모 프로세스로 부터 자식 프로세스를 복제한다.
+ * 
+ * @param thread_name 새로 생성될 자식 프로세스의 이름
+ * @param f 부모의 인터럽트 프레임
+ * @return pid_t 생성된 자식 프로세스의 pid
+ */
 pid_t fork (const char *thread_name, struct intr_frame *f) {
 	check_address(thread_name);
 	return process_fork(thread_name, f);
 }
 
+/**
+ * @brief cmd_line으로 들어온 실행 파일을 실행한다.
+ * 
+ * @param file 실행하려는 파일 이름
+ * @return int 성공 시 0, 실패 시 -1
+ */
 int exec (const char *file){
 	check_address(file);
 
@@ -178,6 +191,12 @@ int exec (const char *file){
 	return 0;
 }
 
+/**
+ * @brief pid에 해당하는 자식 프로세스가 종료될 때까지 기다린다.
+ * 
+ * @param pid 기다리려는 자식 프로세스의 pid
+ * @return int 성공 시 자식 프로세스의 종료 상태, 실패 시 -1
+ */
 int wait (tid_t pid){
 	process_wait(pid);
 }


### PR DESCRIPTION
## free_sema 의 `sema_down` 으로 인한 자식 프로세스의 무한정 대기 상태 해결

<br>

- 🏃🏼‍♀️ Try
   - 250은 miss..
   - ticks 조절을 하다가 300이상으로 설정하니 잘됨

<br>

## 🎉 Test Result
```bash
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/userprog/no-vm/multi-oom
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
All 95 tests passed.
```